### PR TITLE
Remove variant id from Send msgs

### DIFF
--- a/events/response.go
+++ b/events/response.go
@@ -104,6 +104,10 @@ func (e *Event) Open() (*Open, error) {
 // received the push.
 type Send struct {
 	Push
+
+	// VariantID is only present if the notification was sent as part of an
+	// experiment.  Identifies the payload ultimately sent to a device.
+	VariantID *int `json:"variant_id,omitempty"`
 }
 
 // Send returns a Send struct for SEND events. Non-SEND events will return the

--- a/events/response.go
+++ b/events/response.go
@@ -104,10 +104,6 @@ func (e *Event) Open() (*Open, error) {
 // received the push.
 type Send struct {
 	Push
-
-	// VariantID is only present if the notification was sent as part of an
-	// experiment.  Identifies the payload ultimately sent to a device.
-	VariantID string `json:"variant_id,omitempty"`
 }
 
 // Send returns a Send struct for SEND events. Non-SEND events will return the


### PR DESCRIPTION
Variant ID is a deprecated field: http://docs.urbanairship.com/api/connect.html#send-event
